### PR TITLE
Autocomplete: Resets input value in case of reinit

### DIFF
--- a/Resources/public/js/autocomplete/50_autocomplete.js
+++ b/Resources/public/js/autocomplete/50_autocomplete.js
@@ -130,6 +130,8 @@ jQuery(function($, undefined) {
                         val = me.val();
                         if (val && val.length) {
                             input.val(options.filter('[value="'+val+'"]').text());
+                        } else {
+                            input.val('');
                         }
                     };
 


### PR DESCRIPTION
Problematic case:
* Autocomplete field is inited and ready to work
* The user changes the value
* Then, we trigger the `autocompleteReinit` event
* The autocomplete data are well reloaded but the value of the input is still the same as before